### PR TITLE
Validator fix provider credential check

### DIFF
--- a/validator/roles/platform_validations/tasks/main.yml
+++ b/validator/roles/platform_validations/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: "Include platform vars"
-  include_vars: ../vars/platform.yaml
+  include_vars: /data/vars/platform.yaml
 
 - name: "Auth type should be id or user"
   assert:


### PR DESCRIPTION
Validator'deki provider auth credential'ları kontrolü aşağıdaki kontrol ile güncellendi.

Eğer auth.type == id ise;
- id ve key alanlarını kontrol et.

Değilse ve auth.type == user ise;
- user ve password alanlarını kontrol et.